### PR TITLE
Added semicolons to prevent minifying errors

### DIFF
--- a/src/extend.js
+++ b/src/extend.js
@@ -85,19 +85,19 @@
 		//Return expected result from toString
 		child.toString = function(){
 			return to.toString()
-		}
+		};
 
 		//Allow the child to be extended.
 		child.extend = function(target){
 			//Create parent referance and inherentence path.
 			target.parent = to;
 			return ext.apply(child,arguments);
-		}
+		};
 	
 		return child
-	}
+	};
 	//Bootstrap Class by inheriting itself with empty constructor.
 	global.Class = global.Class.extend(function() {
         this.constructor=function(){}
     });
-})(this)
+})(this);


### PR DESCRIPTION
On several places semicolons have been added because it caused errors
due to certain minifying actions if they weren't there.

**Clarification:**

Minified with fix (but kept the structure):

``` js
function(a) {
    "use strict";
    function b(a) {
        a.parent instanceof Function && (b.apply(this, [ a.parent ]), this["super"] = c(this, d(this, this.constructor))), 
        a.apply(this, arguments);
    }
    function c(a, b) {
        for (var c in a) "super" !== c && a[c] instanceof Function && (b[c] = a[c]["super"] || d(a, a[c]));
        return b;
    }
    function d(a, b) {
        var c = a["super"];
        return b["super"] = function() {
            return a["super"] = c, b.apply(a, arguments);
        };
    }
    a.Class = function() {}, a.Class.extend = function e(a) {
        function d() {
            b !== arguments[0] && (b.apply(this, [ a ]), c(this, this), this.initializer instanceof Function && this.initializer.apply(this), 
            this.constructor.apply(this, arguments));
        }
        return d.prototype = new this(b), d.prototype.constructor = d, d.toString = function() {
            return a.toString();
        }, d.extend = function(b) {
            return b.parent = a, e.apply(d, arguments);
        }, d;
    }, a.Class = a.Class.extend(function() {
        this.constructor = function() {};
    });
}(this), function(a, b) {
... other libraries
```

The second line from the bottom is important (`}(this), function(a, b) {`). Without the fix it looks like this when minified:

``` js
function(a) {
...extend code
}(this)(function(a, b)) {
... other libraries
```

This doesn't play nice at all with the other libraries because it causes an error.

Actually only the last semicolon is important from this pull request, but I thought I'd add them to several other methods as well.
